### PR TITLE
feat: Use annotation instead of abstract class

### DIFF
--- a/src/main/java/com/example/demo/core/ShoeCoreLegacy.java
+++ b/src/main/java/com/example/demo/core/ShoeCoreLegacy.java
@@ -1,33 +1,23 @@
 package com.example.demo.core;
 
-import com.example.demo.dto.out.Shoe;
 import com.example.demo.dto.in.ShoeFilter;
 import com.example.demo.dto.in.ShoeFilter.Color;
+import com.example.demo.dto.out.Shoe;
 import com.example.demo.dto.out.Shoes;
 import java.math.BigInteger;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
+@Implementation(version = 1)
 public class ShoeCoreLegacy extends AbstractShoeCore {
-
-  @Override
-  protected BigInteger getVersion() {
-    return BigInteger.ONE;
-  }
 
   @Override
   public Shoes search(final ShoeFilter filter) {
     return Shoes.builder()
-                .shoes(
-                    List.of(
-                        Shoe.builder()
-                            .name("Legacy shoe")
-                            .color(Color.BLUE)
-                            .size(BigInteger.ONE)
-                            .build()
-                    )
-                )
+                .shoes(List.of(Shoe.builder()
+                                   .name("Legacy shoe")
+                                   .color(Color.BLUE)
+                                   .size(BigInteger.ONE)
+                                   .build()))
                 .build();
   }
 }


### PR DESCRIPTION
## Why

Following https://github.com/hypr2771/core-abstract-sample/pull/1, we now have to use `@Implementation(version = 1)` instead of the previous `@Override public BigInteger getVersion()` method.

## What

We now use the `@Implementation`, as suggested.